### PR TITLE
Add ability to specify `type` as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ See [PostCSS] docs for examples for your environment.
 
 - `cssPath` - option to redefine relative images resolving directory (by default the same as css file folder)
 - `imagesPath` - variable to define absolute images base path
-- `type` - define cachebuster type, `mtime` my default, allows: 'mtime, checksum' (checksum based on md5)
+- `type` - define cachebuster type, `mtime` by default, allows: `mtime`, `checksum` (checksum based on md5),
+  or a function which receives the absolute path to the file as an argument and whose return value becomes
+  the url pathname.
 
 
 ## Contributors
 - Gleb Mikheev (https://github.com/glebmachine)
 - Graham Bates (https://github.com/grahambates)
 - Yusuke Yagyu (https://github.com/gyugyu)
-
+- Jackson Ray Hamilton (https://github.com/jacksonrayhamilton)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var url = require('url');
 var fs = require('fs');
 var crypto = require('crypto');
+var chalk = require('chalk');
 
 var postcss = require('postcss');
 var path = require('canonical-path');
@@ -27,6 +28,8 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
 
     if (typeof type === 'function') {
       cachebuster = type(assetPath);
+    } else if (!fs.existsSync(assetPath)) {
+      console.log('Cachebuster:', chalk.yellow('file unreachable or not exists', assetPath));
     } else if (type === 'checksum') {
       if (checksums[assetPath]) {
         cachebuster = checksums[assetPath];
@@ -65,7 +68,9 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
 
       // complete url with cachebuster
       var cachebuster = createCachebuster(assetPath, opts.type);
-      if (typeof opts.type === 'function') {
+      if (!cachebuster) {
+        return;
+      } else if (typeof opts.type === 'function') {
         assetUrl.pathname = cachebuster;
       } else if (assetUrl.search && assetUrl.search.length > 1) {
         assetUrl.search = assetUrl.search + '&v' + cachebuster;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/glebmachine/postcss-cachebuster",
   "dependencies": {
     "canonical-path": "0.0.2",
+    "chalk": "^1.1.1",
     "path": "^0.12.7",
     "postcss": "^5.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/glebmachine/postcss-cachebuster",
   "dependencies": {
     "canonical-path": "0.0.2",
-    "chalk": "^1.1.1",
     "path": "^0.12.7",
     "postcss": "^5.0.12"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var postcss = require('postcss');
 var expect  = require('chai').expect;
+var path = require('path');
 var plugin = require('../');
 var fs = require('fs');
 
@@ -67,6 +68,15 @@ describe('postcss-cachebuster', function () {
         assert('@import url("/css/styles.css");', 
                '@import url("/css/styles.css?v'+cssMtime+'");', 
                { imagesPath : '/test/'}, done);
+    });
+
+    it('Change url with function', function (done) {
+        assert('a { background-image : url("files/horse.jpg"); }',
+               'a { background-image : url("files/horse.abc123.jpg"); }',
+               { type : function (assetPath) {
+                   expect(assetPath).to.equal(path.join(__dirname, 'files/horse.jpg'));
+                   return 'files/horse.abc123.jpg';
+               }, cssPath : '/test/'}, done);
     });
 
 });


### PR DESCRIPTION
Adds the ability to specify a function for `type`. Not sure if this is the best API, just happened to be what I needed to symmetrically integrate this with `grunt-filerev`, which changes the name of a revisioned file, rather than appending a querystring to it. I've heard whispers that in some corners of the Internet, that is necessary for cache invalidation.