### PR TITLE
Fix multiple css imports in single css file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
     }
 
     css.walkAtRules('import', function walkThroughtImports(atrule) {
+      pattern.lastIndex = 0;
       var results = pattern.exec(atrule.params);
       var quote = results[1] || '"';
       var originalUrl = results[2];

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,12 @@ describe('postcss-cachebuster', function () {
                { imagesPath : '/test/'}, done);
     });
 
+    it('Add cachebuster to all imports in the css file', function (done) {
+        assert('@import url("/css/styles.css");@import url("/css/styles.css");', 
+               '@import url("/css/styles.css?v'+cssMtime+'");@import url("/css/styles.css?v'+cssMtime+'");', 
+               { imagesPath : '/test/'}, done);
+    });
+
     it('Change url with function', function (done) {
         assert('a { background-image : url("files/horse.jpg"); }',
                'a { background-image : url("files/horse.abc123.jpg"); }',


### PR DESCRIPTION
[Nice explanation why this lastIndex needs to be reset when g flag is set](http://stackoverflow.com/questions/1520800/why-regexp-with-global-flag-in-javascript-give-wrong-results)

Another possible solution which might be easier to understand is re-creating the regexp instance each time the function `walkThroughtImports` is called:

```
var regexp = new RegExp(pattern, 'g');
var results = regexp.exec(atrule.params);
```
^^This one is better for readability, but worse for performance. It's up to you.