### PR TITLE
Added 'paramName' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
   opts.imagesPath = opts.imagesPath ? process.cwd() + opts.imagesPath : process.cwd();
   opts.cssPath = opts.cssPath ? process.cwd()+opts.cssPath : false;
   opts.type = opts.type || 'mtime';
+  opts.paramName = opts.paramName || 'v';
 
   function createCachebuster(assetPath, type) {
     var cachebuster;
@@ -73,9 +74,9 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
       } else if (typeof opts.type === 'function') {
         assetUrl.pathname = cachebuster;
       } else if (assetUrl.search && assetUrl.search.length > 1) {
-        assetUrl.search = assetUrl.search + '&v' + cachebuster;
+        assetUrl.search = assetUrl.search + '&' + opts.paramName + cachebuster;
       } else {
-        assetUrl.search = '?v' + cachebuster;
+        assetUrl.search = '?' + opts.paramName + cachebuster;
       }
     }
 


### PR DESCRIPTION
This option will allow users to specify their own parameter name. It
defaults to 'v' to keep backwards compatibility.

I plan on using this plugin in conjunction with other cachebusting methods for our other static content which uses a different query string parameter name.

I have added a 'paramName' option which defaults to 'v' so that I can specify my own name in the config.

I think that it's a fairly simple but useful addition, so I hope that you integrate it.

Thanks.