### PR TITLE
give original path to type function

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,11 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
   opts.type = opts.type || 'mtime';
   opts.paramName = opts.paramName || 'v';
 
-  function createCachebuster(assetPath, type) {
+  function createCachebuster(assetPath, origPath, type) {
     var cachebuster;
 
     if (typeof type === 'function') {
-      cachebuster = type(assetPath);
+      cachebuster = type(assetPath, origPath);
     } else if (!fs.existsSync(assetPath)) {
       console.log('Cachebuster:', chalk.yellow('file unreachable or not exists', assetPath));
     } else if (type === 'checksum') {
@@ -68,7 +68,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
       var assetPath = resolveUrl(assetUrl, inputFile, opts.imagesPath);
 
       // complete url with cachebuster
-      var cachebuster = createCachebuster(assetPath, opts.type);
+      var cachebuster = createCachebuster(assetPath, assetUrl.pathname, opts.type);
       if (!cachebuster) {
         return;
       } else if (typeof opts.type === 'function') {

--- a/test/test.js
+++ b/test/test.js
@@ -79,8 +79,9 @@ describe('postcss-cachebuster', function () {
     it('Change url with function', function (done) {
         assert('a { background-image : url("files/horse.jpg"); }',
                'a { background-image : url("files/horse.abc123.jpg"); }',
-               { type : function (assetPath) {
+               { type : function (assetPath, origPath) {
                    expect(assetPath).to.equal(path.join(__dirname, 'files/horse.jpg'));
+                   expect(origPath).to.equal('files/horse.jpg');
                    return 'files/horse.abc123.jpg';
                }, cssPath : '/test/'}, done);
     });


### PR DESCRIPTION
Send the original path along with the absolute path to the `type` function.

This will allow the following:

```css
/* input.css */
body {
  background: url('./image.png');
}
```

```js
const options = {
  type: function (assetPath, origPath) {
    const hash = fs.statSync(assetPath).mtime.getTime().toString(16);
    return origPath.replace(/\.(\w+)$/, `.${hash}.$1`);
  }
}
```

```css
/* output.css */
body {
  background: url('./image.163a3b5f138.png');
}
```