### PR TITLE
Configurable hash algorithm

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
       if (checksums[assetPath]) {
         cachebuster = checksums[assetPath];
       } else {
-        var data = fs.readFileSync(assetPath).toString();
+        var data = fs.readFileSync(assetPath);
         cachebuster = crypto.createHash('md5')
           .update(data)
           .digest('hex');

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
   opts.cssPath = opts.cssPath ? process.cwd()+opts.cssPath : false;
   opts.type = opts.type || 'mtime';
   opts.paramName = opts.paramName || 'v';
+  opts.hashAlgorithm = opts.hashAlgorithm || 'md5';
 
   function createCachebuster(assetPath, origPath, type) {
     var cachebuster;
@@ -36,7 +37,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
         cachebuster = checksums[assetPath];
       } else {
         var data = fs.readFileSync(assetPath);
-        cachebuster = crypto.createHash('md5')
+        cachebuster = crypto.createHash(opts.hashAlgorithm)
           .update(data)
           .digest('hex');
 


### PR DESCRIPTION
This commit makes the hash algorithm configurable via a configuration option.

It also removes an unnecessary `toString()` call before hashing the file's contents. This update has a nice side effect of making the resulting md5 hashes match what you would get by executing `md5sum filename` on the command line.