### PR TITLE
Configurable hash algorithm - tests and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ See [PostCSS] docs for examples for your environment.
 
 - `cssPath` - option to redefine relative images resolving directory (by default the same as css file folder)
 - `imagesPath` - variable to define absolute images base path
-- `type` - define cachebuster type, `mtime` by default, allows: `mtime`, `checksum` (checksum based on md5),
+- `type` - define cachebuster type, `mtime` by default, allows: `mtime`, `checksum` (checksum based on a hash algorithm),
   or a function which receives the absolute path to the file as an argument and whose return value becomes
   the url pathname.
+- `hashAlgorithm` - the hash algorithm to use when `type` is set to `checksum` (defaults to `md5`).
+  See the [crypto.createHash()](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options)
+  documentation for information about available hash algorithms.
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ See [PostCSS] docs for examples for your environment.
 - `type` - define cachebuster type, `mtime` by default, allows: `mtime`, `checksum` (checksum based on a hash algorithm),
   or a function which receives the absolute path to the file as an argument and whose return value becomes
   the url pathname.
+- `paramName` - prefix for the cachebuster value added to an asset's query
+  string (defaults to `v`). The default of `v` produces URLs like
+  `images/horse.jpg?v32f14a88dcf`. You can include an `=` to format it as a
+  key/value parameter. For example, setting `paramName` to `v=` could produce
+  URLs like `images/horse.jpg?v=32f14a88dcf`.
 - `hashAlgorithm` - the hash algorithm to use when `type` is set to `checksum` (defaults to `md5`).
   See the [crypto.createHash()](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options)
   documentation for information about available hash algorithms.

--- a/index.js
+++ b/index.js
@@ -33,15 +33,19 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
     } else if (!fs.existsSync(assetPath)) {
       console.log('Cachebuster:', chalk.yellow('file unreachable or not exists', assetPath));
     } else if (type === 'checksum') {
-      if (checksums[assetPath]) {
-        cachebuster = checksums[assetPath];
+      // Used to distinguish between different hash algorithms among the
+      // remembered checksum values in the `checksums` array.
+      var checksumKey = [assetPath, opts.hashAlgorithm].join('|');
+      
+      if (checksums[checksumKey]) {
+        cachebuster = checksums[checksumKey];
       } else {
         var data = fs.readFileSync(assetPath);
         cachebuster = crypto.createHash(opts.hashAlgorithm)
           .update(data)
           .digest('hex');
 
-        checksums[assetPath] = cachebuster;
+        checksums[checksumKey] = cachebuster;
       }
     } else {
       var mtime = fs.statSync(assetPath).mtime;

--- a/test/test.js
+++ b/test/test.js
@@ -85,5 +85,17 @@ describe('postcss-cachebuster', function () {
                    return 'files/horse.abc123.jpg';
                }, cssPath : '/test/'}, done);
     });
+    
+    it('Change url with default checksum', function (done) {
+        assert('a { background-image : url("files/horse.jpg"); }',
+               'a { background-image : url("files/horse.jpg?vac17ceac5567ecf01eab7c474b3b8426"); }',
+               { type : 'checksum', cssPath : '/test/'}, done);
+    });
+    
+    it('Change url with checksum using specified hash algorithm', function (done) {
+        assert('a { background-image : url("files/horse.jpg"); }',
+               'a { background-image : url("files/horse.jpg?v8a88fc3de434b972f5bebdcd33474cc2259310c1"); }',
+               { type : 'checksum', hashAlgorithm : 'sha1', cssPath : '/test/'}, done);
+    });
 
 });


### PR DESCRIPTION
This pull request adds unit tests for checksum options for default and specified hash algorithms (and fixed an issue that the new tests revealed). It also adds documentation for the `hashAlgorithm` and `paramName` configuration options.