### PR TITLE
Add ability to configure additional supported CSS properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,45 @@ See [PostCSS] docs for examples for your environment.
 - `hashAlgorithm` - the hash algorithm to use when `type` is set to `checksum` (defaults to `md5`).
   See the [crypto.createHash()](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options)
   documentation for information about available hash algorithms.
+- `additionalProps` - array of additional CSS properties to support
+- `supportedProps` - replacement array of supported CSS properties (see below
+  for the default list of supported properties).
 
+Default supported properties:
+
+- `background`
+- `background-image`
+- `border-image`
+- `behavior`
+- `src`
+
+Add to this list by setting the `additionalProps` configuration option.
+To add support for `mask-image` properties, for example:
+
+```js
+postcss([ 
+  require('postcss-cachebuster')({
+    additionalProps : [
+      'mask-image',
+      '-webkit-mask-image'
+    ]
+  })
+])
+```
+
+Replace the default list by setting the `supportedProps` configuration option.
+To limit the cachbusting to background images only, for example:
+
+```js
+postcss([ 
+  require('postcss-cachebuster')({
+    supportedProps : [
+      'background',
+      'background-image'
+    ]
+  })
+])
+```
 
 ## Contributors
 - Gleb Mikheev (https://github.com/glebmachine)

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
   opts.type = opts.type || 'mtime';
   opts.paramName = opts.paramName || 'v';
   opts.hashAlgorithm = opts.hashAlgorithm || 'md5';
+  supportedProps = opts.supportedProps || supportedProps;
+  supportedProps = supportedProps.concat(opts.additionalProps || []);
 
   function createCachebuster(assetPath, origPath, type) {
     var cachebuster;

--- a/test/test.js
+++ b/test/test.js
@@ -112,4 +112,16 @@ describe('postcss-cachebuster', function () {
                { type : 'checksum', hashAlgorithm : 'sha1', cssPath : '/test/'}, done);
     });
 
+    it('Skip unrecognized CSS property', function (done) {
+        assert('a { mask-image : url("/files/horse.jpg"); }',
+               'a { mask-image : url("/files/horse.jpg"); }',
+               { imagesPath : '/test/'}, done);
+    });
+
+    it('Add cachebuster for additional specified CSS property', function (done) {
+        assert('a { mask-image : url("/files/horse.jpg"); }',
+               'a { mask-image : url("/files/horse.jpg?v'+horseMtime+'"); }', 
+               { imagesPath : '/test/', additionalProps: ['mask-image']}, done);
+    });
+
 });


### PR DESCRIPTION
This commit proposes the ability to configure additional supported CSS properties.

My current use case is to add support for the `mask-image`/`-webkit-mask-image` CSS properties. Rather than just adding to the hard-coded list of properties, this pull request proposes to allow the list of CSS properties to be appended or replaced via configuration options.

With this commit, the `supportedProps` array can be completely replaced by a `supportedProps` option. Additional properties can be appended to `supportedProps` by listing them in an `additionalProps` option.

Therefore, if a user wishes to restrict the list of supported properties, they can set the `supportedProps` configuration option to `['background', 'background-image']`, for example. On the other hand, if a user only wants to add support for one or two more properties, they can be added by setting the `additionalProps` configuration option to `['mask-image', '-webkit-mask-image']`, for example.

I am seeking feedback on this proposal. If the proposal is agreeable, I will also add unit tests and documentation before marking the draft pull request ready for review.

* [x] unit tests
* [x] documentation