### PR TITLE
Fix failing test when cssPath is undefined and there is no input filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = postcss.plugin('postcss-cachebuster', function (opts) {
   }
 
   return function (css) {
-    var inputFile = opts.cssPath || css.source.input.file;
+    var inputFile = opts.cssPath || css.source.input.file || '';
 
     function updateAssetUrl(assetUrl) {
       var assetPath = resolveUrl(assetUrl, inputFile, opts.imagesPath);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "postcss": "^5.0.12"
   },
   "devDependencies": {
-    "chai": "3.0.0",
+    "chai": "^4.0",
+    "sinon": "^4.0",
+    "sinon-chai": "^3.0",
     "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
     "eslint-plugin-import": "1.9.2",


### PR DESCRIPTION
Fixes #3 

The problem described in #3 seems to appear in the scenario when cssPath is undefined, there is no input CSS filename (such as in the unit tests where the CSS string is passed in directly), and the asset file is not found.

In this scenario, the `inputFile` variable gets set to undefined:

```js
// opts.cssPath and css.source.input.file are both undefined
var inputFile = opts.cssPath || css.source.input.file;
```

The `inputFile` ends up getting passed to the `path()` module, which requires a string parameter (that isn't undefined). The included fix is to fallback to an empty string:

```js
var inputFile = opts.cssPath || css.source.input.file || '';
```

This pull request also enhances the "Skip unresolved images" test that was failing by verifying the `console.log` warning message that is emitted when the image file isn't found.